### PR TITLE
UseRWX & Default Sleepmask (no kit) Support Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A proof-of-concept [User-Defined Reflective Loader (UDRL)](https://hstechdocs.he
 ## UDRL Usage Considerations
 The built-in [Cobalt Strike](https://www.cobaltstrike.com/) reflective loader is robust,  handling all [Malleable PE evasion features](https://hstechdocs.helpsystems.com/manuals/cobaltstrike/current/userguide/content/topics/malleable-c2-extend_pe-memory-indicators.htm) Cobalt Strike has to offer. The major disadvantage to using a custom UDRL is Malleable PE evasion features may or may not be supported out-of-the-box.  
 
-The objective of the public BokuLoader project is to assist red teams wanting to create their own in-house Cobalt Strike UDRL. The project aims to support all worthwhile CS Malleable PE evasion features. Some evasion features leverage CS integration, others have been recreated completely, and some are unsupported.   
+The objective of the public BokuLoader project is to assist red teams in creating their own in-house Cobalt Strike UDRL. The project aims to support all worthwhile CS Malleable PE evasion features. Some evasion features leverage CS integration, others have been recreated completely, and some are unsupported.   
 
 _Before using this project, in any form, you should properly test the evasion features are working as intended. Between the C code and the Aggressor script, compilation with different versions of operating systems, compilers, and Java may  return different results._   
 


### PR DESCRIPTION
Added support for malleable PE "set userwx" option. When using default "sleepmask true" (without sleepmask kit), you will need to set "userwx" to "true" to avoid writing to non-writable beacon.text memory. When using sleepmask kit which supports RX beacon.text memory, set "sleepmask true" && "userwx false".