### PR TITLE
Fix a bug where img maybe accessed with VA

### DIFF
--- a/src/BokuLoader.h
+++ b/src/BokuLoader.h
@@ -314,7 +314,7 @@ void  HellDescent(void);
 unsigned long halosGateDown(void * ntdllApiAddr, unsigned long index);
 unsigned long halosGateUp(void * ntdllApiAddr, unsigned long index);
 unsigned long getSyscallNumber(void * functionAddress);
-void parseDLL(Dll * dll);
+void parseDLL(Dll * dll, BOOL isImg);
 SIZE_T CharStringToWCharString( PWCHAR Destination, PCHAR Source, SIZE_T MaximumAllowed );
 SIZE_T StringLengthA(LPCSTR String);
 


### PR DESCRIPTION
- The ExportedDirectory (VA) will be de-referenced in the `getExportedAddressTable` and 3 other functions.
- `parseDLL` is used on the `raw_beacon_dll` which is an image
- The VA may not exist on the image thus triggering an access violation (though maybe rarely)
(Not sure if there is a more elegant solution though)