### PR TITLE
Add strreps for SMB, TCP and DNS

### DIFF
--- a/dist/BokuLoader.cna
+++ b/dist/BokuLoader.cna
@@ -444,6 +444,10 @@ sub boku_strrep {
 	$beacon_dll = strrep($beacon_dll, "Microsoft Base Cryptographic Provider v1.0", "12367321236742382543232341241261363163151d");
 	$beacon_dll = strrep($beacon_dll, "(admin)", "(tomin)");
 	$beacon_dll = strrep($beacon_dll, "beacon", "bacons");
+	$beacon_dll = strrep($beacon_dll, "pivot", "bacon");
+	$beacon_dll = strrep($beacon_dll, "dnsb", "baco");
+	$beacon_dll = strrep($beacon_dll, ".rl100k.", ".bacons.");
+
 	return $beacon_dll;
 }
 


### PR DESCRIPTION
Hi boku,

First of all, thank you for supporting the community with this awesome project! BokuLoader is a great example of how to implement your UDRL properly.

I'm not sure if it is officially supported, but I would like to contribute a few minor string replacements for DNS, SMB and TCP beacons as an example. We are simply replacing one static signature with another here, just like in the HTTPS beacon example. I preserved the original "bacon" style of the project.

E.g. 64-bit TCP beacon shell code would now contain:
bacon.x64.bacons.dll

instead of:
pivot.x64.rl100k.dll

Feel free to accept or decline as you see fit. Keep up the great work!

Cheers,
0xbad53c